### PR TITLE
Correction for handover of a message to pushover

### DIFF
--- a/main.js
+++ b/main.js
@@ -642,7 +642,7 @@ function sendPushover(event) {
         const ev = formatEvent(event, true);
         if (ev) {
             const text = ev.event + (ev.val !== undefined ? ` => ${ev.val.toString()}${states[event.id].unit || ''}` : '');
-            adapter.log.debug(`Send to 'telegram.${instances.join(',')}' => ${text}`);
+            adapter.log.debug(`Send to 'pushover.${instances.join(',')}' => ${text}`);
 
             instances.forEach(num =>
                 adapter.sendTo(`pushover.${num}`, 'send', {text}));

--- a/main.js
+++ b/main.js
@@ -645,7 +645,7 @@ function sendPushover(event) {
             adapter.log.debug(`Send to 'pushover.${instances.join(',')}' => ${text}`);
 
             instances.forEach(num =>
-                adapter.sendTo(`pushover.${num}`, 'send', {text}));
+                adapter.sendTo(`pushover.${num}`, 'send', text));
         }
     }
 


### PR DESCRIPTION
hand over message as string, not as an array

(I am not an expert, so please check carefully. At least for my installation it only works when handover as string)